### PR TITLE
Tweaks

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [libraries]
 
-android-gradle = "com.android.tools.build:gradle:7.0.4"
+android-gradle = "com.android.tools.build:gradle:7.1.2"
 
 androidx-appCompat = "androidx.appcompat:appcompat:1.4.0"
 androidx-constraintLayout = "androidx.constraintlayout:constraintlayout:2.0.1"

--- a/xml-theme-demo/src/main/java/dev/drewhamilton/skylight/android/brand/demo/DemoActivity.kt
+++ b/xml-theme-demo/src/main/java/dev/drewhamilton/skylight/android/brand/demo/DemoActivity.kt
@@ -47,8 +47,7 @@ class DemoActivity : AppCompatActivity() {
             AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
         }
         isDynamicColorsEnabled = savedInstanceState?.getBoolean(KEY_IS_DYNAMIC_COLORS_ENABLED) ?: false
-        val defaultFullscreen = Build.VERSION.SDK_INT >= 29
-        isFullscreen = savedInstanceState?.getBoolean(KEY_IS_FULLSCREEN) ?: defaultFullscreen
+        isFullscreen = savedInstanceState?.getBoolean(KEY_IS_FULLSCREEN) ?: true
         applySelectedTheme()
         WindowCompat.setDecorFitsSystemWindows(window, !isFullscreen)
 
@@ -167,7 +166,7 @@ class DemoActivity : AppCompatActivity() {
         }
     }
 
-    private fun showBottomSheet() = BottomSheetDialog(this).apply {
+    private fun showBottomSheet() = FixedBottomSheetDialog(this).apply {
         val bottomSheetBinding = BottomSheetBinding.inflate(layoutInflater)
         setContentView(bottomSheetBinding.root)
 

--- a/xml-theme-demo/src/main/java/dev/drewhamilton/skylight/android/brand/demo/DemoActivity.kt
+++ b/xml-theme-demo/src/main/java/dev/drewhamilton/skylight/android/brand/demo/DemoActivity.kt
@@ -36,6 +36,12 @@ class DemoActivity : AppCompatActivity() {
     private var isBottomSheetShowing: Boolean = false
     private var isAlertDialogShowing: Boolean = false
 
+    // DeferredColor must be used because resource colors can't refer to attributes:
+    private val navigationBarBackdrop = SdkIntDeferredColor(
+        minSdk = DeferredColor.Resource(R.color.navigationBarBackdrop),
+        sdk27 = DeferredColor.Attribute(android.R.attr.colorBackground).withAlpha(0.87f),
+    )
+
     override fun onCreate(savedInstanceState: Bundle?) {
         if (savedInstanceState == null) {
             AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
@@ -48,6 +54,7 @@ class DemoActivity : AppCompatActivity() {
 
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+        binding.navigationBarBackdrop.setBackgroundColor(navigationBarBackdrop.resolve(this))
 
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, windowInsets ->
             with(windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())) {
@@ -56,7 +63,7 @@ class DemoActivity : AppCompatActivity() {
                 binding.scrollView.updatePadding(bottom = bottom)
 
                 binding.statusBarBackdrop.setHeight(top)
-                binding.navigationBarBackrop.setHeight(bottom)
+                binding.navigationBarBackdrop.setHeight(bottom)
             }
 
             windowInsets

--- a/xml-theme-demo/src/main/java/dev/drewhamilton/skylight/android/brand/demo/FixedBottomSheetDialog.kt
+++ b/xml-theme-demo/src/main/java/dev/drewhamilton/skylight/android/brand/demo/FixedBottomSheetDialog.kt
@@ -1,0 +1,34 @@
+package dev.drewhamilton.skylight.android.brand.demo
+
+import android.content.Context
+import android.graphics.Color
+import android.view.View
+import com.google.android.material.bottomsheet.BottomSheetDialog
+
+/**
+ * Fixes a bug in [BottomSheetDialog] where it does not respect
+ * [android.R.attr.windowLightNavigationBar]'s value in the dialog theme.
+ */
+class FixedBottomSheetDialog(context: Context) : BottomSheetDialog(context) {
+
+    @Suppress("DEPRECATION") // Copying superclass logic
+    override fun onAttachedToWindow() {
+        val window = window
+        val initialSystemUiVisibility = window?.decorView?.systemUiVisibility ?: 0
+
+        super.onAttachedToWindow()
+
+        if (window != null) {
+            // If the navigation bar is translucent at all, the BottomSheet should be edge to edge
+            val drawEdgeToEdge = edgeToEdgeEnabled && Color.alpha(window.navigationBarColor) < 0xFF
+            if (drawEdgeToEdge) {
+                // Copied from super.onAttachedToWindow:
+                val edgeToEdgeFlags =
+                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+
+                // Fix super-class's window flag bug by respecting the intial system UI visibility:
+                window.decorView.systemUiVisibility = edgeToEdgeFlags or initialSystemUiVisibility
+            }
+        }
+    }
+}

--- a/xml-theme-demo/src/main/res/layout/demo.xml
+++ b/xml-theme-demo/src/main/res/layout/demo.xml
@@ -155,17 +155,18 @@
       tools:layout_height="24dp" />
 
   <View
-      android:id="@+id/navigationBarBackrop"
+      android:id="@+id/navigationBarBackdrop"
       android:layout_width="0dp"
       android:layout_height="0dp"
 
       android:background="@color/navigationBarBackdrop"
-      android:elevation="1000dp"
 
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintBottom_toBottomOf="parent"
 
-      tools:layout_height="56dp" />
+      tools:layout_height="56dp"
+      tools:alpha="0.87"
+      tools:background="?android:colorBackground" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/xml-theme-demo/src/main/res/layout/palette.xml
+++ b/xml-theme-demo/src/main/res/layout/palette.xml
@@ -7,6 +7,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
 
+    style="?materialCardViewOutlinedStyle"
+
     tools:ignore="HardcodedText"
     >
 

--- a/xml-theme-demo/src/main/res/values-night-v29/colors.xml
+++ b/xml-theme-demo/src/main/res/values-night-v29/colors.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-  <color name="navigationBarBackdrop">#00000000</color>
-</resources>

--- a/xml-theme-demo/src/main/res/values-v27/colors.xml
+++ b/xml-theme-demo/src/main/res/values-v27/colors.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-  <color name="navigationBarBackdrop">#ddffffff</color>
-</resources>

--- a/xml-theme-demo/src/main/res/values-v29/colors.xml
+++ b/xml-theme-demo/src/main/res/values-v29/colors.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-  <color name="navigationBarBackdrop">#00ffffff</color>
-</resources>

--- a/xml-theme/src/main/res/values-v27/overlays.xml
+++ b/xml-theme/src/main/res/values-v27/overlays.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+  <style
+      name="ThemeOverlay.Skylight.Light.BottomSheetDialog"
+      parent="Base.V27.ThemeOverlay.Skylight.Light.BottomSheetDialog"
+      />
+
+  <style
+      name="Base.V27.ThemeOverlay.Skylight.Light.BottomSheetDialog"
+      parent="Base.V21.ThemeOverlay.Skylight.Light.BottomSheetDialog"
+      >
+
+    <item name="android:navigationBarColor">#00ffffff</item>
+    <item name="android:windowLightNavigationBar">true</item>
+
+  </style>
+
+</resources>

--- a/xml-theme/src/main/res/values-v29/theme.xml
+++ b/xml-theme/src/main/res/values-v29/theme.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+  <style name="Theme.Skylight.Light" parent="Base.V29.Theme.Skylight.Light" />
+  <style name="Theme.Skylight.Dark" parent="Base.V29.Theme.Skylight.Dark" />
+
+  <style name="Base.V29.Theme.Skylight.Light" parent="Base.V27.Theme.Skylight.Light">
+    <item name="android:enforceStatusBarContrast">false</item>
+    <item name="android:enforceNavigationBarContrast">false</item>
+  </style>
+
+  <style name="Base.V29.Theme.Skylight.Dark" parent="Base.V21.Theme.Skylight.Dark">
+    <item name="android:enforceStatusBarContrast">false</item>
+    <item name="android:enforceNavigationBarContrast">false</item>
+  </style>
+
+</resources>

--- a/xml-theme/src/main/res/values/overlays.xml
+++ b/xml-theme/src/main/res/values/overlays.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+  <style
+      name="ThemeOverlay.Skylight.Light.BottomSheetDialog"
+      parent="Base.V21.ThemeOverlay.Skylight.Light.BottomSheetDialog"
+      />
+
+  <style
+      name="ThemeOverlay.Skylight.Dark.BottomSheetDialog"
+      parent="ThemeOverlay.Material3.BottomSheetDialog"
+      />
+
+  <style
+      name="Base.V21.ThemeOverlay.Skylight.Light.BottomSheetDialog"
+      parent="ThemeOverlay.Material3.BottomSheetDialog"
+      >
+
+    <item name="android:navigationBarColor">?colorOutline</item>
+
+  </style>
+
+</resources>

--- a/xml-theme/src/main/res/values/theme.xml
+++ b/xml-theme/src/main/res/values/theme.xml
@@ -72,6 +72,10 @@
     <item name="shapeAppearanceLargeComponent">@style/ShapeAppearance.Skylight.LargeComponent</item>
     <!--endregion-->
 
+    <!--region Theme overlays-->
+    <item name="bottomSheetDialogTheme">@style/ThemeOverlay.Skylight.Light.BottomSheetDialog</item>
+    <!--endregion-->
+
     <!--region Widget styles-->
     <item name="materialCardViewStyle">?materialCardViewFilledStyle</item>
     <!--endregion-->
@@ -130,6 +134,10 @@
     <item name="shapeAppearanceSmallComponent">@style/ShapeAppearance.Skylight.SmallComponent</item>
     <item name="shapeAppearanceMediumComponent">@style/ShapeAppearance.Skylight.MediumComponent</item>
     <item name="shapeAppearanceLargeComponent">@style/ShapeAppearance.Skylight.LargeComponent</item>
+    <!--endregion-->
+
+    <!--region Theme overlays-->
+    <item name="bottomSheetDialogTheme">@style/ThemeOverlay.Skylight.Dark.BottomSheetDialog</item>
     <!--endregion-->
 
     <!--region Widget styles-->

--- a/xml-theme/src/main/res/values/theme.xml
+++ b/xml-theme/src/main/res/values/theme.xml
@@ -66,10 +66,14 @@
 
     <item name="elevationOverlayColor">?colorTertiary</item>
 
-    <!--region shape attributes-->
+    <!--region Shape attributes-->
     <item name="shapeAppearanceSmallComponent">@style/ShapeAppearance.Skylight.SmallComponent</item>
     <item name="shapeAppearanceMediumComponent">@style/ShapeAppearance.Skylight.MediumComponent</item>
     <item name="shapeAppearanceLargeComponent">@style/ShapeAppearance.Skylight.LargeComponent</item>
+    <!--endregion-->
+
+    <!--region Widget styles-->
+    <item name="materialCardViewStyle">?materialCardViewFilledStyle</item>
     <!--endregion-->
   </style>
 
@@ -122,10 +126,14 @@
 
     <item name="elevationOverlayColor">?colorTertiary</item>
 
-    <!--region shape attributes-->
+    <!--region Shape attributes-->
     <item name="shapeAppearanceSmallComponent">@style/ShapeAppearance.Skylight.SmallComponent</item>
     <item name="shapeAppearanceMediumComponent">@style/ShapeAppearance.Skylight.MediumComponent</item>
     <item name="shapeAppearanceLargeComponent">@style/ShapeAppearance.Skylight.LargeComponent</item>
+    <!--endregion-->
+
+    <!--region Widget styles-->
+    <item name="materialCardViewStyle">?materialCardViewFilledStyle</item>
     <!--endregion-->
   </style>
 


### PR DESCRIPTION
Tweak some theme defaults:
1. Add a bottom sheet dialog theme with transparent navigation bar
2. Disable system bar contrast enforcement (require consuming apps to handle this)
3. Change default card style from outlined to filled